### PR TITLE
Add Gemnasium dependency status image to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ObfuscateId [![Build Status](https://secure.travis-ci.org/namick/obfuscate_id.png)](http://travis-ci.org/namick/obfuscate_id)
+# ObfuscateId [![Build Status](https://secure.travis-ci.org/namick/obfuscate_id.png)](http://travis-ci.org/namick/obfuscate_id) [![Dependency Status](https://gemnasium.com/namick/obfuscate_id.png)](https://gemnasium.com/namick/obfuscate_id)
 
 ObfuscateId is a simple Ruby on Rails plugin that hides your seqential Active Record ids.  Although having nothing to do with security, it can be used to make database record id information non-obvious.
 


### PR DESCRIPTION
Love the idea for the gem. I've run into this plenty of times and have resorted to SecureRandom.hex but this is much prettier in my opinion, not to mention not requiring an additional column is a big win. Thanks!
