### PR TITLE
Removed passing options to Rails find

### DIFF
--- a/lib/obfuscate_id.rb
+++ b/lib/obfuscate_id.rb
@@ -29,8 +29,7 @@ module ObfuscateId
           scope = deobfuscate_id(scope)
         end
       end
-      options.delete(:no_obfuscated_id)
-      super(scope, options)
+      super(scope)
     end
 
     def has_obfuscated_id?


### PR DESCRIPTION
`find` is simplified in Rails 4.1, so passing the options breaks it.

http://api.rubyonrails.org/classes/ActiveRecord/FinderMethods.html#method-i-find
http://apidock.com/rails/v3.2.13/ActiveRecord/FinderMethods/find
