### PR TITLE
Solved problem with default spin being to large for really, really long ...

### DIFF
--- a/lib/obfuscate_id.rb
+++ b/lib/obfuscate_id.rb
@@ -48,7 +48,7 @@ module ObfuscateId
       number = name.split("").collect do |char|
         alphabet.index(char)
       end
-      number.shift(16).join.to_i
+      number.shift(12).join.to_i
     end
 
   end

--- a/spec/dummy/app/models/model_with_very_long_name.rb
+++ b/spec/dummy/app/models/model_with_very_long_name.rb
@@ -1,3 +1,0 @@
-class ModelWithVeryLongName < ActiveRecord::Base
-  # attr_accessible :title, :body
-end

--- a/spec/dummy/db/migrate/20140219090804_create_model_with_very_long_names.rb
+++ b/spec/dummy/db/migrate/20140219090804_create_model_with_very_long_names.rb
@@ -1,8 +1,0 @@
-class CreateModelWithVeryLongNames < ActiveRecord::Migration
-  def change
-    create_table :model_with_very_long_names do |t|
-
-      t.timestamps
-    end
-  end
-end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -20,7 +20,7 @@ ActiveRecord::Schema.define(:version => 20140219090804) do
     t.datetime "updated_at", :null => false
   end
 
-  create_table "model_with_very_long_names", :force => true do |t|
+  create_table "some_really_absurdly_long_named_class_that_you_wouldnt_have_thought_ofs", :force => true do |t|
     t.datetime "created_at", :null => false
     t.datetime "updated_at", :null => false
   end

--- a/spec/lib/obfuscate_id_spec.rb
+++ b/spec/lib/obfuscate_id_spec.rb
@@ -48,12 +48,12 @@ describe "#obfuscate_id_spin" do
 
     describe "for model with long name" do
       before do
-        class ModelWithVeryLongName < ActiveRecord::Base
+        class SomeReallyAbsurdlyLongNamedClassThatYouWouldntHaveThoughtOf < ActiveRecord::Base
           obfuscate_id
         end
       end
         it 'compute default spin correctly' do
-          rec = ModelWithVeryLongName.new(id: 1)
+          rec = SomeReallyAbsurdlyLongNamedClassThatYouWouldntHaveThoughtOf.new(id: 1)
           expect(rec.to_param).to_not raise_error(/bignum too big/)
         end
     end


### PR DESCRIPTION
Issue #10 was still not solved: I was getting a "Bignum too big to convert into `long'" error for a rather long class name. So I created this test case for an absurdly long class name solved the problem, by making the spin shorter.
