### PR TITLE
Change rails dependency

### DIFF
--- a/obfuscate_id.gemspec
+++ b/obfuscate_id.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*"] + ["MIT-LICENSE", "Rakefile", "README.md"]
 
   s.add_dependency "scatter_swap",    "~> 0.0.3"
-  s.add_dependency "rails",           "~> 4.2.0"
+  s.add_dependency "rails",           ">= 4.0.0"
 
   s.add_development_dependency "sqlite3"
   s.add_development_dependency "rspec-rails"


### PR DESCRIPTION
Rails 4.2 isn't really necessary so why force projects to use 4.2+
