### PR TITLE
Ensure that #deobfuscate_id returns an integer by casting to_i.

### DIFF
--- a/lib/obfuscate_id.rb
+++ b/lib/obfuscate_id.rb
@@ -35,7 +35,7 @@ module ObfuscateId
     end
 
     def deobfuscate_id(obfuscated_id)
-      ObfuscateId.show(obfuscated_id, self.obfuscate_id_spin)
+      ObfuscateId.show(obfuscated_id, self.obfuscate_id_spin).to_i
     end
 
     # Generate a default spin from the Model name
@@ -77,7 +77,7 @@ module ObfuscateId
     end
 
     def deobfuscate_id(obfuscated_id)
-      self.class.deobfuscate_id(obfuscated_id)
+      self.class.deobfuscate_id(obfuscated_id).to_i
     end
   end
 end

--- a/spec/lib/obfuscate_id_spec.rb
+++ b/spec/lib/obfuscate_id_spec.rb
@@ -76,7 +76,7 @@ describe ObfuscateId do
 
     let(:user) { User.create(id: 1) }
 
-    subject(:deobfuscated_id) { User.deobfuscate_id(user.to_param).to_i }
+    subject(:deobfuscated_id) { User.deobfuscate_id(user.to_param) }
 
     it "reverses the obfuscated id" do
       should eq(user.id)


### PR DESCRIPTION
This saves the inevitable explicit conversion before the returned value can be used in a lookup query.
