### PR TITLE
include GlobalId fix needed to support Rails 4.2 in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,13 @@ ActiveRecord reverses this obfuscated id back to the plain id before building th
 
 * This is not security.  obfuscate_id was created to lightly mask record id numbers for the casual user.  If you need to really secure your database ids (hint, you probably don't), you need to use real encryption like AES.
 * To properly generate obfuscated urls, make sure you trigger the model's `to_param` method by passing in the whole object rather than just the id; do this: `post_path(@post)` not this: `post_path(@post.id)`.
+* To use with Rails 4.2 ActiveJob features such as ActionMailer's `deliver_later`, update how GlobalId deserializes ActiveRecord instances:
+```
+# config/initializer/global_id.rb
+GlobalID::Locator.use Rails.application.railtie_name.remove("_application").dasherize do |gid|
+  gid.model_class.find_by_id gid.model_id
+end
+```
 
 ## Versions
 


### PR DESCRIPTION
@namick please merge to make this fix more obvious to new users running Rails 4.2.

This PR adds @chengguangnan’s fix for 4.2 to the README as suggested in the issue thread  https://github.com/namick/obfuscate_id/issues/36#issuecomment-103785087
