### PR TITLE
Adjusted the gemspec file to allow Rails 5 usage

### DIFF
--- a/obfuscate_id.gemspec
+++ b/obfuscate_id.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*"] + ["MIT-LICENSE", "Rakefile", "README.md"]
 
   s.add_dependency "scatter_swap",    "~> 0.0.3"
-  s.add_dependency "rails",           "~> 4.2.0"
+  s.add_dependency "rails",           ">= 4.2.0"
 
   s.add_development_dependency "sqlite3"
   s.add_development_dependency "rspec-rails"


### PR DESCRIPTION
This is the same change as RGP has proposed. I can't see why the tests fail for his tweak though. As such, I am repeating it (apologies if this is a bad idea).

I have used the change, with Rails 5 beta 2, without issue.
