### PR TITLE
Re-enable ActiveRecord `lock!` functionality

### DIFF
--- a/lib/obfuscate_id.rb
+++ b/lib/obfuscate_id.rb
@@ -66,7 +66,7 @@ module ObfuscateId
 
       fresh_object =
         if options && options[:lock]
-          self.class.unscoped { self.class.lock(options[:lock]).find(id, options) }
+          self.class.unscoped { self.class.lock(options[:lock]).find(id) }
         else
           self.class.unscoped { self.class.find(id, options) }
         end

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -27,6 +27,12 @@ describe Post do
       expect(subject.id).to eql id
       expect(subject.to_param).to eql param
     end
+
+    context "while locking" do
+      it "does not throw an error" do
+        expect(lambda { subject.lock! }).to_not raise_error
+      end
+    end
   end
 
   describe "Finding multiple records" do


### PR DESCRIPTION
`lock` just delegates to `lock!` so adding a spec showing that `ActiveRecord::Locking::Pessimistic#lock!` is broken.

The problem is in the reimplementation of `reload` which calls `lock` but this returns a Relation not the ActiveRecord class so the overridden `find(*args)` that can handle `{no_obfuscated_id: true}` never gets called.

I went with just removing the options hash from the call to `Relation#find` as it doesn't appear it would be used while locking anyway.
