### PR TITLE
Make #to_param behave as in default AR models

### DIFF
--- a/lib/obfuscate_id.rb
+++ b/lib/obfuscate_id.rb
@@ -53,7 +53,7 @@ module ObfuscateId
 
   module InstanceMethods
     def to_param
-      ObfuscateId.hide(self.id, self.class.obfuscate_id_spin)
+      ObfuscateId.hide(self.id, self.class.obfuscate_id_spin) if self.id
     end
 
     # Override ActiveRecord::Persistence#reload

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -38,4 +38,12 @@ describe Post do
       should eq([post1, post2])
     end
   end
+
+  context 'When not persisted yet' do
+    let (:new_post) { Post.new content: "one" }
+
+    it 'has no param' do
+      expect(new_post.to_param).to be_nil
+    end
+  end
 end


### PR DESCRIPTION
The default behavior of ActiveRecord models is for `#to_param` to return nil when `#persisted?` is false.
