### PR TITLE
Make to_param behave as in default AR models

### DIFF
--- a/lib/obfuscate_id.rb
+++ b/lib/obfuscate_id.rb
@@ -53,7 +53,7 @@ module ObfuscateId
 
   module InstanceMethods
     def to_param
-      ObfuscateId.hide(self.id, self.class.obfuscate_id_spin)
+      ObfuscateId.hide(self.id, self.class.obfuscate_id_spin) if self.id
     end
 
     # Override ActiveRecord::Persistence#reload

--- a/spec/dummy/Gemfile
+++ b/spec/dummy/Gemfile
@@ -23,7 +23,7 @@ gem 'jbuilder', '~> 2.0'
 # bundle exec rake doc:rails generates the API under doc/api.
 gem 'sdoc', '~> 0.4.0', group: :doc
 
-gem 'obfuscate_id', '~> 0.2.0'
+gem 'obfuscate_id', path: '../../'
 
 # Use ActiveModel has_secure_password
 # gem 'bcrypt', '~> 3.1.7'
@@ -44,4 +44,3 @@ group :development, :test do
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
 end
-

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -38,4 +38,12 @@ describe Post do
       should eq([post1, post2])
     end
   end
+
+  context 'When not persisted yet' do
+    let (:new_post) { Post.new content: "one" }
+
+    it 'has no param' do
+      expect(new_post.to_param).to be_nil
+    end
+  end
 end


### PR DESCRIPTION
This makes obfuscate_id behave like the default ActiveRecord models, where unsaved models return `nil` on calls to `to_param`
